### PR TITLE
Service logic refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-suite</artifactId>
+			<version>1.10.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>test</scope>

--- a/src/main/java/com/academy/AcademyApplication.java
+++ b/src/main/java/com/academy/AcademyApplication.java
@@ -1,7 +1,16 @@
 package com.academy;
 
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
 
 @SpringBootApplication
 public class AcademyApplication {
@@ -12,6 +21,7 @@ public class AcademyApplication {
 
 
 	@Bean
+	@ConditionalOnProperty(name = "starting.scripts.enabled", havingValue = "true", matchIfMissing = false)
 	CommandLineRunner populateData(DataSource dataSource) {
 		return args -> {
 			Resource resource = new ClassPathResource("sql-scripts/populateRoles.sql");

--- a/src/main/java/com/academy/models/Tag.java
+++ b/src/main/java/com/academy/models/Tag.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -23,6 +24,7 @@ import java.util.List;
 @Table(name="tag")
 @Getter
 @Setter
+@ToString(exclude="services")
 public class Tag {
 
     @Column(name="id")
@@ -48,22 +50,4 @@ public class Tag {
     @ManyToMany(mappedBy = "tags")
     @JsonIgnore
     private List<Service> services = new ArrayList<>();
-
-    public void removeAllServices() {
-        for (Service service : new ArrayList<>(services)) {
-            service.getTags().remove(this);
-        }
-        services.clear();
-    }
-
-    @Override
-    public String toString() {
-        return "Tag{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
-                ", custom=" + custom +
-                ", createdAt=" + createdAt +
-                ", updatedAt=" + updatedAt +
-                '}';
-    }
 }

--- a/src/main/java/com/academy/models/service/Service.java
+++ b/src/main/java/com/academy/models/service/Service.java
@@ -87,20 +87,4 @@ public class Service {
 
     @OneToMany(mappedBy = "service", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ServiceProvider> serviceProviders = new ArrayList<>();
-
-    private void removeAllTags() {
-        for (Tag tag : new ArrayList<>(tags)) {
-            tag.getServices().remove(this);
-        }
-        tags.clear();
-    }
-
-    private void removeServiceTypeLink() {
-        serviceType.getServices().remove(this);
-    }
-
-    public void removeAllLinks() {
-        removeAllTags();
-        removeServiceTypeLink();
-    }
 }

--- a/src/main/java/com/academy/services/ProviderPermissionService.java
+++ b/src/main/java/com/academy/services/ProviderPermissionService.java
@@ -31,6 +31,8 @@ public class ProviderPermissionService {
         return providerPermissionRepository.findAllByServiceProviderId(serviceProviderId).stream()
                 .map(ProviderPermission::getPermission).toList();
     }
+
+    @Transactional
     public ServiceProvider createPermissionsViaList(List<ProviderPermissionEnum> permissions, ServiceProvider serviceProvider){
         List<ProviderPermission> providerPermissions = new ArrayList<>();
         for(ProviderPermissionEnum permission : permissions){
@@ -56,6 +58,8 @@ public class ProviderPermissionService {
             providerPermissionRepository.delete(permission);
         }
     }
+
+    @Transactional
     public void deleteAllByServiceProvider(Long serviceProviderId) {
         ServiceProvider serviceProvider = serviceProviderService.getServiceProviderEntityById(serviceProviderId);
         providerPermissionRepository.deleteAll(serviceProvider.getPermissions());

--- a/src/main/java/com/academy/services/ServiceProviderService.java
+++ b/src/main/java/com/academy/services/ServiceProviderService.java
@@ -50,11 +50,13 @@ public class ServiceProviderService {
                 .map(serviceProviderMapper::toResponseDTO);
     }
 
+    @Transactional
     public ServiceProviderResponseDTO createServiceProviderWithDTO(ServiceProviderRequestDTO dto) {
         ServiceProvider serviceProvider = createServiceProvider(dto);
         return serviceProviderMapper.toResponseDTO(serviceProvider);
     }
 
+    @Transactional
     public ServiceProvider createServiceProvider(ServiceProviderRequestDTO dto) {
         Member member = memberService.getMemberEntityById(dto.memberId());
 
@@ -72,7 +74,7 @@ public class ServiceProviderService {
         return serviceProviderRepository.save(saved);
     }
 
-
+    @Transactional
     public ServiceProviderResponseDTO updateServiceProvider(long id, ServiceProviderRequestDTO details) {
         ServiceProvider serviceProvider = serviceProviderRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(ServiceProvider.class, id));

--- a/src/main/java/com/academy/services/ServiceProviderService.java
+++ b/src/main/java/com/academy/services/ServiceProviderService.java
@@ -1,4 +1,3 @@
-// ServiceProviderService.java
 package com.academy.services;
 
 import com.academy.dtos.service_provider.ServiceProviderMapper;
@@ -12,6 +11,7 @@ import com.academy.models.service.service_provider.ServiceProvider;
 import com.academy.repositories.ServiceProviderRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,7 +29,7 @@ public class ServiceProviderService {
     public ServiceProviderService(ServiceProviderRepository serviceProviderRepository,
                                   ServiceProviderMapper serviceProviderMapper,
                                   MemberService memberService,
-                                  ServiceService serviceService,
+                                  @Lazy ServiceService serviceService,
                                   ProviderPermissionService providerPermissionService) {
         this.serviceProviderRepository = serviceProviderRepository;
         this.serviceProviderMapper = serviceProviderMapper;

--- a/src/main/java/com/academy/services/ServiceProviderService.java
+++ b/src/main/java/com/academy/services/ServiceProviderService.java
@@ -10,11 +10,9 @@ import com.academy.models.Member;
 import com.academy.models.service.Service;
 import com.academy.models.service.service_provider.ProviderPermissionEnum;
 import com.academy.models.service.service_provider.ServiceProvider;
-import com.academy.repositories.MemberRepository;
-import com.academy.utils.Utils;
 import com.academy.repositories.ServiceProviderRepository;
+import com.academy.utils.Utils;
 import jakarta.transaction.Transactional;
-import com.academy.repositories.ServiceRepository;
 import org.apache.coyote.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -189,15 +187,17 @@ public class ServiceProviderService {
         return optionalServiceProvider.get();
     }
 
-
+    @Transactional
     public void deleteAllPermissions(Long serviceProviderId) {
         ServiceProvider serviceProvider = getServiceProviderEntityById(serviceProviderId);
         providerPermissionService.deleteAllByServiceProvider(serviceProvider.getId());
     }
 
+    @Transactional
     public void addPermissions(ServiceProvider serviceProvider,List<ProviderPermissionEnum> permissions){
         providerPermissionService.createPermissionsViaList(permissions, serviceProvider);
     }
+
     public List<Long> findMemberIdsByServiceId(Long serviceId) {
         return serviceProviderRepository.findMemberIdsByServiceId(serviceId);
     }

--- a/src/main/java/com/academy/services/ServiceService.java
+++ b/src/main/java/com/academy/services/ServiceService.java
@@ -80,8 +80,7 @@ public class ServiceService {
         Service existing = getServiceEntityById(id);
 
         List<ProviderPermissionEnum> permissions = getPermissionsByProviderUsernameAndServiceId(username, existing.getId());
-        if(permissions == null || !permissions.contains(ProviderPermissionEnum.UPDATE))
-            throw new AuthenticationException("Member doesn't have permission to update service");
+        checkPermission(permissions, ProviderPermissionEnum.UPDATE, "update");
 
         linkServiceToType(existing, dto.serviceTypeName());
         linkServiceToTags(existing, dto.tagNames());
@@ -107,8 +106,7 @@ public class ServiceService {
         Service service = getServiceEntityById(id);
         String username =  authenticationFacade.getUsername();
         List<ProviderPermissionEnum> permissions = getPermissionsByProviderUsernameAndServiceId(username, id);
-        if(permissions == null || !permissions.contains(ProviderPermissionEnum.READ))
-            throw new AuthenticationException("Member doesn't have permission to read service");
+        checkPermission(permissions, ProviderPermissionEnum.READ, "read");
         return serviceMapper.toDto(service, getPermissionsByProviderUsernameAndServiceId(username, service.getId()));
     }
 
@@ -118,8 +116,7 @@ public class ServiceService {
         String username =  authenticationFacade.getUsername();
         Service service = getServiceEntityById(id);
         List<ProviderPermissionEnum> permissions = getPermissionsByProviderUsernameAndServiceId(username, id);
-        if(permissions == null || !permissions.contains(ProviderPermissionEnum.DELETE))
-            throw new AuthenticationException("Member doesn't have permission to delete service");
+        checkPermission(permissions, ProviderPermissionEnum.DELETE, "delete");
 
         cleanUpService(service);
         serviceRepository.delete(service);
@@ -193,6 +190,12 @@ public class ServiceService {
         return getById(serviceId);
     }
     */
+
+    private void checkPermission(List<ProviderPermissionEnum> permissions, ProviderPermissionEnum requestedPermission, String permissionName) {
+        if(permissions == null || !permissions.contains(requestedPermission))
+            throw new AuthenticationException("Member doesn't have permission to " + permissionName + " service");
+    }
+
     public Service getServiceEntityById(Long id) {
         return serviceRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(Service.class, id));
     }

--- a/src/main/java/com/academy/services/ServiceService.java
+++ b/src/main/java/com/academy/services/ServiceService.java
@@ -13,8 +13,6 @@ import com.academy.models.Tag;
 import com.academy.models.service.Service;
 import com.academy.models.service.service_provider.ProviderPermissionEnum;
 import com.academy.models.service.service_provider.ServiceProvider;
-import com.academy.repositories.ProviderPermissionRepository;
-import com.academy.repositories.ServiceProviderRepository;
 import com.academy.repositories.ServiceRepository;
 import com.academy.specifications.ServiceSpecifications;
 import jakarta.transaction.Transactional;
@@ -22,7 +20,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -218,6 +215,10 @@ public class ServiceService {
     */
     public Service getServiceEntityById(Long id) {
         return serviceRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(Service.class, id));
+    }
+
+    public List<Service> getServiceEntitiesByIds(List<Long> ids) {
+        return serviceRepository.findAllById(ids);
     }
 
     public boolean existsById(Long serviceId) {

--- a/src/main/java/com/academy/services/ServiceTypeService.java
+++ b/src/main/java/com/academy/services/ServiceTypeService.java
@@ -35,8 +35,7 @@ public class ServiceTypeService {
     // Update
     @Transactional
     public ServiceTypeResponseDTO update(Long id, ServiceTypeRequestDTO dto) {
-        ServiceType existing = serviceTypeRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(ServiceType.class, id));
+        ServiceType existing = getServiceTypeEntityById(id);
 
         serviceTypeMapper.updateEntityFromDto(dto, existing);
         ServiceType updated = serviceTypeRepository.save(existing);
@@ -53,21 +52,23 @@ public class ServiceTypeService {
 
     // Read one
     public ServiceTypeResponseDTO getById(Long id) {
-        ServiceType serviceType = serviceTypeRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(ServiceType.class, id));
+        ServiceType serviceType = getServiceTypeEntityById(id);
         return serviceTypeMapper.toDto(serviceType);
     }
 
     // Delete
     @Transactional
     public void delete(Long id) {
-        ServiceType serviceType = serviceTypeRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(ServiceType.class, id));
+        ServiceType serviceType = getServiceTypeEntityById(id);
         serviceTypeRepository.delete(serviceType);
     }
 
-    public ServiceType findByNameOrThrow(String name) {
+    public ServiceType getServiceTypeEntityByName(String name) {
         return serviceTypeRepository.findByName(name)
                 .orElseThrow(() -> new EntityNotFoundException(ServiceType.class, " with name " + name + " not found"));
+    }
+
+    public ServiceType getServiceTypeEntityById(Long id) {
+        return serviceTypeRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(ServiceType.class, id));
     }
 }

--- a/src/main/java/com/academy/services/TagService.java
+++ b/src/main/java/com/academy/services/TagService.java
@@ -9,7 +9,6 @@ import com.academy.models.service.Service;
 import com.academy.repositories.TagRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,8 +32,7 @@ public class TagService {
     public TagResponseDTO create(TagRequestDTO dto) {
         Tag tag = tagMapper.toEntity(dto);
 
-        List<Service> services = serviceService.getServiceEntitiesByIds(dto.serviceIds());
-        linkTagsToService(tag, services);
+        linkTagsToService(tag, dto.serviceIds());
 
         Tag savedTag = tagRepository.save(tag);
         return tagMapper.toDto(savedTag);
@@ -42,21 +40,11 @@ public class TagService {
 
     @Transactional
     public TagResponseDTO update(Long id, TagRequestDTO dto) {
-        Tag existing = tagRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(Tag.class, id));
+        Tag existing = getTagEntityById(id);
 
-        // Remove existing service associations
-        for (Service service : new ArrayList<>(existing.getServices())) {
-            service.getTags().remove(existing);
-        }
-        existing.getServices().clear();
-
-        // Handle associations with services
-        List<Service> newServices = serviceService.getServiceEntitiesByIds(dto.serviceIds());
-        linkTagsToService(existing, newServices);
+        linkTagsToService(existing, dto.serviceIds());
 
         tagMapper.updateEntityFromDto(dto, existing);
-
         return tagMapper.toDto(tagRepository.save(existing));
     }
 
@@ -70,8 +58,7 @@ public class TagService {
 
     // Read one
     public TagResponseDTO getById(Long id) {
-        Tag tag = tagRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(Tag.class, id));
+        Tag tag = getTagEntityById(id);
 
         return tagMapper.toDto(tag);
     }
@@ -79,8 +66,7 @@ public class TagService {
     // Delete
     @Transactional
     public void delete(Long id) {
-        Tag tag = tagRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(Tag.class, id));
+        Tag tag = getTagEntityById(id);
 
         removeTagFromAllServices(tag); // Break relationship with services
         tagRepository.delete(tag);
@@ -97,24 +83,8 @@ public class TagService {
         List<String> newTagNames = tagNames.stream()
                 .filter(name -> !existingTagNames.contains(name))
                 .toList();
-
-        // Create new tags for names that don't exist
-        List<Tag> newTags = newTagNames.stream()
-                .map(name -> {
-                    Tag tag = new Tag();
-                    tag.setName(name);
-                    tag.setCustom(true);
-                    return tag;
-                })
-                .toList();
-
-        if (!newTags.isEmpty()) {
-            try {
-                tagRepository.saveAll(newTags); // Try inserting all new tags
-            } catch (DataIntegrityViolationException e) {
-                // Race condition likely occurred: // TODO log
-            }
-        }
+        List<Tag> newTags = createTagsFromNames(newTagNames);
+        tagRepository.saveAll(newTags);
 
         // Combine existing and new tags and return them
         List<Tag> allTags = new ArrayList<>(existingTags);
@@ -122,16 +92,32 @@ public class TagService {
         return allTags;
     }
 
-    @Transactional
-    public void removeTagFromAllServices(Tag tag) {
+    public List<Tag> createTagsFromNames(List<String> tagNames) {
+        return tagNames.stream()
+                .map(name -> {
+                    Tag tag = new Tag();
+                    tag.setName(name);
+                    tag.setCustom(true);
+                    return tag;
+                })
+                .toList();
+    }
+
+    public Tag getTagEntityById(Long id) {
+        return tagRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(Tag.class, id));
+    }
+
+    private void removeTagFromAllServices(Tag tag) {
         for (Service service : new ArrayList<>(tag.getServices())) {
             service.getTags().remove(tag);
         }
         tag.getServices().clear();
-        tagRepository.save(tag);
     }
 
-    private void linkTagsToService(Tag tag, List<Service> services) {
+    private void linkTagsToService(Tag tag, List<Long> serviceIds) {
+        removeTagFromAllServices(tag);
+
+        List<Service> services = serviceService.getServiceEntitiesByIds(serviceIds);
         tag.setServices(services);
         for (Service service : services) {
             service.getTags().add(tag);

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{
+  "properties": [
+    {
+      "name": "starting.scripts.enabled",
+      "type": "java.lang.String",
+      "defaultValue": false,
+      "description": "Enable or disable the populateData() Scripts."
+  }
+] }

--- a/src/test/java/com/academy/AcademyApplicationTests.java
+++ b/src/test/java/com/academy/AcademyApplicationTests.java
@@ -1,13 +1,18 @@
 package com.academy;
 
-import org.junit.jupiter.api.Test;
+import com.academy.availability.AvailabilityIntegrationTests;
+import com.academy.global_configurations.GlobalConfigurationTests;
+import com.academy.services.ServiceIntegrationTests;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Suite
+@SelectClasses({
+		ServiceIntegrationTests.class,
+		AvailabilityIntegrationTests.class,
+		GlobalConfigurationTests.class
+})
 @SpringBootTest
-class AcademyApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
-
+public class AcademyApplicationTests {
 }

--- a/src/test/java/com/academy/AcademyApplicationTests.java
+++ b/src/test/java/com/academy/AcademyApplicationTests.java
@@ -3,6 +3,7 @@ package com.academy;
 import com.academy.availability.AvailabilityIntegrationTests;
 import com.academy.global_configurations.GlobalConfigurationTests;
 import com.academy.services.ServiceIntegrationTests;
+import com.academy.services.ServicePermissionsIntegrationTests;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,7 +12,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SelectClasses({
 		ServiceIntegrationTests.class,
 		AvailabilityIntegrationTests.class,
-		GlobalConfigurationTests.class
+		GlobalConfigurationTests.class,
+		ServicePermissionsIntegrationTests.class,
 })
 @SpringBootTest
 public class AcademyApplicationTests {

--- a/src/test/java/com/academy/availability/AvailabilityIntegrationTests.java
+++ b/src/test/java/com/academy/availability/AvailabilityIntegrationTests.java
@@ -10,7 +10,11 @@ import com.academy.models.Role;
 import com.academy.models.ServiceType;
 import com.academy.models.service.Service;
 import com.academy.models.service.service_provider.ProviderPermissionEnum;
-import com.academy.repositories.*;
+import com.academy.repositories.AvailabilityRepository;
+import com.academy.repositories.MemberRepository;
+import com.academy.repositories.RoleRepository;
+import com.academy.repositories.ServiceRepository;
+import com.academy.repositories.ServiceTypeRepository;
 import com.academy.services.AvailabilityService;
 import com.academy.services.ServiceProviderService;
 import org.apache.coyote.BadRequestException;
@@ -26,7 +30,8 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/academy/global_configurations/GlobalConfigurationTests.java
+++ b/src/test/java/com/academy/global_configurations/GlobalConfigurationTests.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SpringBootTest
 @Transactional
 @ExtendWith(SpringExtension.class)
-class GlobalConfigurationTests {
+public class GlobalConfigurationTests {
 
     private final GlobalConfigurationService globalConfigurationService;
     private final GlobalConfigurationRepository globalConfigurationRepository;

--- a/src/test/java/com/academy/services/ServiceIntegrationTests.java
+++ b/src/test/java/com/academy/services/ServiceIntegrationTests.java
@@ -16,14 +16,12 @@ import com.academy.repositories.ServiceRepository;
 import com.academy.repositories.ServiceTypeRepository;
 import com.academy.repositories.TagRepository;
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
@@ -38,8 +36,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 @Transactional
 @ExtendWith(SpringExtension.class)
 @WithMockUser(username = "owner")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-class ServiceIntegrationTests {
+public class ServiceIntegrationTests {
     private final ServiceService serviceService;
     private final TagService tagService;
     private final ServiceRepository serviceRepository;
@@ -47,8 +44,6 @@ class ServiceIntegrationTests {
     private final TagRepository tagRepository;
     private final MemberRepository memberRepository;
     private final RoleRepository roleRepository;
-    private final ServiceProviderRepository serviceProviderRepository;
-    private final ProviderPermissionRepository providerPermissionRepository;
 
     @Autowired
     public ServiceIntegrationTests(ServiceService serviceService,
@@ -69,8 +64,6 @@ class ServiceIntegrationTests {
         this.tagRepository = tagRepository;
         this.memberRepository = memberRepository;
         this.roleRepository = roleRepository;
-        this.serviceProviderRepository = serviceProviderRepository;
-        this.providerPermissionRepository = providerPermissionRepository;
     }
 
     private ServiceType serviceType;
@@ -105,33 +98,6 @@ class ServiceIntegrationTests {
         tag2.setName("tag2");
         tag2.setCustom(false);
         tagRepository.save(tag2);
-    }
-
-    @AfterEach
-    void tearDown() {
-        /*
-        providerPermissionRepository.deleteAllInBatch();
-        serviceProviderRepository.deleteAllInBatch();
-
-        List<Service> services = serviceRepository.findAll();
-        List<Tag> tags = tagRepository.findAll();
-
-        for (Service service : services) {
-            List<Tag> serviceTags = new ArrayList<>(service.getTags());
-            for (Tag tag : serviceTags) {
-                tag.getServices().remove(service);
-            }
-            service.getTags().clear();
-        }
-        serviceRepository.saveAll(services);
-        tagRepository.saveAll(tags);
-
-        serviceRepository.deleteAllInBatch();
-        tagRepository.deleteAllInBatch();
-        serviceTypeRepository.deleteAllInBatch();
-        memberRepository.deleteAllInBatch();
-        roleRepository.deleteAllInBatch();
-        */
     }
 
     private ServiceRequestDTO createDTO(String name, String description, String serviceTypeName, List<String> tags) {

--- a/src/test/java/com/academy/services/ServiceIntegrationTests.java
+++ b/src/test/java/com/academy/services/ServiceIntegrationTests.java
@@ -17,7 +17,6 @@ import com.academy.repositories.ServiceTypeRepository;
 import com.academy.repositories.TagRepository;
 import jakarta.transaction.Transactional;
 import org.apache.coyote.BadRequestException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -123,7 +122,7 @@ public class ServiceIntegrationTests {
     }
 
     @Test
-    void updateService_invalidServiceType_throwsException() {
+    void updateService_invalidServiceType_throwsException() throws BadRequestException {
         ServiceRequestDTO serviceRequestDTO = createDTO("Test Service", "Test Description", "Test Service Type", List.of("tag1"));
 
         ServiceResponseDTO createdResponse = serviceService.create(serviceRequestDTO);
@@ -143,7 +142,7 @@ public class ServiceIntegrationTests {
     }
 
     @Test
-    void deleteTag_associatedWithService() {
+    void deleteTag_associatedWithService() throws BadRequestException {
         Tag tag2 = createTag("tag2");
         ServiceRequestDTO serviceRequestDTO = createDTO("Test Service", "Test Description", "Test Service Type", List.of("tag2"));
 

--- a/src/test/java/com/academy/services/ServicePermissionsIntegrationTests.java
+++ b/src/test/java/com/academy/services/ServicePermissionsIntegrationTests.java
@@ -8,6 +8,7 @@ import com.academy.dtos.service_type.ServiceTypeRequestDTO;
 import com.academy.dtos.service_type.ServiceTypeResponseDTO;
 import com.academy.exceptions.AuthenticationException;
 import com.academy.models.Member;
+import com.academy.models.Role;
 import com.academy.models.ServiceType;
 import com.academy.models.service.Service;
 import com.academy.models.service.service_provider.ProviderPermissionEnum;
@@ -16,28 +17,24 @@ import com.academy.repositories.MemberRepository;
 import com.academy.repositories.RoleRepository;
 import jakarta.transaction.Transactional;
 import org.apache.coyote.BadRequestException;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import com.academy.models.Role;
 
-import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -115,7 +112,7 @@ public class ServicePermissionsIntegrationTests {
         assertNotNull(response);
         assertEquals("Service", response.name());
 
-        Service service = serviceService.getEntityById(response.id());
+        Service service = serviceService.getServiceEntityById(response.id());
         assertNotNull(service);
         assertEquals("Service", service.getName());
 
@@ -200,7 +197,7 @@ public class ServicePermissionsIntegrationTests {
                                 new ArrayList<>()
                         )
         );
-                Service service = serviceService.getEntityById(serviceId);
+                Service service = serviceService.getServiceEntityById(serviceId);
                 assertEquals("ServiceUpdated", service.getName());
                 assertEquals(30.0, service.getPrice());
     }


### PR DESCRIPTION
[mudar repositórios usados em serviços para serviços](https://trello.com/c/WpqU37Ob)
[Refactor ServiceService, re-organizar lógica de tudo](https://trello.com/c/4LWMqESo)

basicamente tive a dar cleanup na lógica dos Services + testes dos Services, para tornar-se muito mais readable, principalmente a reduzir repetição mas também para livrar de más práticas (exemplo, no caso de remover código de lógica da entity Service).

não estava em cartões do trello mas também fiz o seguinte:

- O AcademyApplicationTests agora é uma test suite: basta correr este ficheiro que corre automaticamente os testes todos (quando criarem um novo ficheiro de testes, tem que o adicionar aqui na @ SelectClasses)
- Adicionei uma opção de ter os scripts de populateData() a correr ou não no startup, basta ter um config no application.properties chamado:

starting.scripts.enabled=true/false